### PR TITLE
chore: bump openssl version to 3.4.5

### DIFF
--- a/get_openssl.sh
+++ b/get_openssl.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 set -e
 
-OPENSSL_VERSION="3.0.17"
+OPENSSL_VERSION="3.4.5"
 OPENSSL_DIR="/usr/local/ssl"
 CONFIGURE_PARAMS="no-shared no-tests no-idea no-mdc2 no-rc5 no-zlib no-ui-console no-ssl3 no-ssl3-method enable-rfc3779 enable-cms no-capieng no-rdrand"
 


### PR DESCRIPTION
Bumps openssl version to 3.4.5. 

How I tested:

```
1. docker build -f u20.04-gcc14-dev.Dockerfile -t ghcr.io/romange/ubuntu-dev:20-gcc14 . 
2. docker run -it --rm --privileged -v /home/ubuntu/dragonfly:/dragonfly -w /dragonfly ghcr.io/romange/ubuntu-dev:20-gcc14 bash 
3. grep -r "OPENSSL" build-dbg/CMakeCache.txt | grep -i "version\|include\|lib"  --> version 3.4.5
4. compiled helio && run tls_socket_test --> all green
5. compiled dragonfly && run tls_replication_test and all connection_test --> all green
```